### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     },
     "type": "library",
     "require": {
-        "pear/pear_exception": "*"
+        "pear/pear_exception": "*",
+        "pear/pear-core-minimal": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "*"


### PR DESCRIPTION
requires PEAR class in [mime.php:66](https://github.com/pear/Mail_Mime/blob/master/Mail/mime.php#L66)

altho there exists [pear/pear-core-minimal](https://github.com/pear/pear-core-minimal), shoud that be used directly or `pear-core-minimal` should provide `pear/pear`?