### PR TITLE
Use valid SPDX identifier in composer.json license field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "include-path": [
         "./"
     ],
-    "license": "BSD Style",
+    "license": "BSD-3-clause",
     "name": "pear/mail_mime",
     "support": {
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Mail_Mime",


### PR DESCRIPTION
"BSD style" is ambiguous and not a valid SPDX identifier, so explicitly
state that it is BSD-3-clause.