### PR TITLE
Suppress deprecation message for get_magic_quotes_runtime()

### DIFF
--- a/Mail/mime.php
+++ b/Mail/mime.php
@@ -494,7 +494,7 @@ class Mail_mime
         }
 
         // Temporarily reset magic_quotes_runtime and read file contents
-        if ($magic_quote_setting = get_magic_quotes_runtime()) {
+        if ($magic_quote_setting = @get_magic_quotes_runtime()) {
             @ini_set('magic_quotes_runtime', 0);
         }
 
@@ -769,7 +769,7 @@ class Mail_mime
         }
 
         // Temporarily reset magic_quotes_runtime and read file contents
-        if ($magic_quote_setting = get_magic_quotes_runtime()) {
+        if ($magic_quote_setting = @get_magic_quotes_runtime()) {
             @ini_set('magic_quotes_runtime', 0);
         }
 
@@ -822,7 +822,7 @@ class Mail_mime
         }
 
         // Temporarily reset magic_quotes_runtime and read file contents
-        if ($magic_quote_setting = get_magic_quotes_runtime()) {
+        if ($magic_quote_setting = @get_magic_quotes_runtime()) {
             @ini_set('magic_quotes_runtime', 0);
         }
 

--- a/Mail/mimePart.php
+++ b/Mail/mimePart.php
@@ -340,7 +340,7 @@ class Mail_mimePart
             $encoded['body'] = $this->getEncodedData($this->body, $this->encoding);
         } else if ($this->body_file) {
             // Temporarily reset magic_quotes_runtime for file reads and writes
-            if ($magic_quote_setting = get_magic_quotes_runtime()) {
+            if ($magic_quote_setting = @get_magic_quotes_runtime()) {
                 @ini_set('magic_quotes_runtime', 0);
             }
             $body = $this->getEncodedDataFromFile($this->body_file, $this->encoding);
@@ -392,7 +392,7 @@ class Mail_mimePart
         }
 
         // Temporarily reset magic_quotes_runtime for file reads and writes
-        if ($magic_quote_setting = get_magic_quotes_runtime()) {
+        if ($magic_quote_setting = @get_magic_quotes_runtime()) {
             @ini_set('magic_quotes_runtime', 0);
         }
 


### PR DESCRIPTION
At least on my RoundCube site running with PHP 7.4 beta2 emits lots of them.

```
PHP Deprecated:  Function get_magic_quotes_runtime() is deprecated in /roundcubemail/vendor/pear/mail_mime/Mail/mime.php on line 497
```

- `get_magic_quotes_runtime` has returned false since PHP 5.4, but hasn't yet been removed (instead, it always returns `false`).
- `set_magic_quotes_runtime` has been deprecated since 5.3, was removed entirely in PHP 7.

---

I wonder whether `get_magic_quotes_runtime` is going to be removed in PHP 8. In that case, we may just create a function/method, say `my_get_magic_quotes_runtime`, to polyfill it and also fix this deprecation by directly return `false` for PHP >= 5.4.0 in that function.