### PR TITLE
fixed licence in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "include-path": [
         "./"
     ],
-    "license": "BSD-3-clause",
+    "license": "BSD-3-Clause",
     "name": "pear/mail_mime",
     "support": {
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Mail_Mime",


### PR DESCRIPTION
license was written wrong, which makes tools break, that match on that string to gather licenses of software dependencies.


according to https://opensource.org/licenses/BSD-3-Clause
it should be "BSD-3-Clause" instead of "BSD-3-clause".

so to follow https://getcomposer.org/doc/04-schema.md#license
> Optional, but it is highly recommended to supply this. More identifiers are listed at the [SPDX Open Source License Registry](https://spdx.org/licenses/).